### PR TITLE
Groups in coup popup to bottom modal (Pure CSS)

### DIFF
--- a/src/components/utils/BasicModal.css
+++ b/src/components/utils/BasicModal.css
@@ -91,3 +91,41 @@
     transform: scale(1);
   }
 }
+
+@media only screen and (max-width: 800px) {
+  .modal {
+    position: absolute !important;
+    width: 100% !important;
+    height: 80% !important;
+    bottom: 0px !important;
+    left: 0px !important;
+    right: 0px !important;
+    top: auto !important;
+  }
+
+  .basic-modal-content {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .basic-modal-container .modal {
+    animation: animateMobile 0.3s;
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+  }
+
+}
+
+@keyframes animateMobile {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Implemented bottom modal with pure css for groups in coup popup. 

Description:
- Pure css implementation
- rounded corner same px as TimelineBottomSheet
- bottom to up entry animation for mobile
- overflow scroll only for content

Callouts:
- Tried to use/follow TimelineBottomSheet initially but the content is different because it includes the references section

Possible improvements:
- Remove 'x' button for closing (tapping outside will also close)